### PR TITLE
Implement player listing API

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -47,6 +47,7 @@
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4">
                 <button name="command" value="status" class="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded">Status</button>
                 <button type="button" onclick="autoRefresh()" class="bg-indigo-500 hover:bg-indigo-600 px-4 py-2 rounded">Auto Refresh</button>
+                <button type="button" onclick="fetchPlayers()" class="bg-teal-500 hover:bg-teal-600 px-4 py-2 rounded">Refresh Players</button>
                 <button name="command" value="map de_dust2" class="bg-green-500 hover:bg-green-600 px-4 py-2 rounded">Map: Dust2</button>
                 <button name="command" value="sv_restart 1" class="bg-purple-500 hover:bg-purple-600 px-4 py-2 rounded">Restart</button>
             </div>
@@ -67,6 +68,8 @@
                     {{ output }}
                 </div>
             {% endif %}
+
+            <div id="players" class="mt-6 space-y-2"></div>
         </form>
     </div>
 
@@ -99,6 +102,40 @@
 
                 form.submit();
             }, 10000); // every 10 seconds
+        }
+
+        async function fetchPlayers() {
+            const server = document.getElementById('server').value;
+            if (!server) return;
+            const res = await fetch(`/players/${server}`);
+            const data = await res.json();
+            const container = document.getElementById('players');
+            container.innerHTML = '';
+            (data.players || []).forEach(p => {
+                const row = document.createElement('div');
+                row.className = 'flex items-center space-x-2';
+                const info = document.createElement('span');
+                info.textContent = `${p.name} (#${p.userid})`;
+                row.appendChild(info);
+                const kick = document.createElement('button');
+                kick.textContent = 'Kick';
+                kick.className = 'bg-red-600 hover:bg-red-700 px-2 py-1 rounded';
+                kick.onclick = () => playerAction(server, p.userid, 'kick');
+                row.appendChild(kick);
+                const ban = document.createElement('button');
+                ban.textContent = 'Ban';
+                ban.className = 'bg-red-800 hover:bg-red-900 px-2 py-1 rounded';
+                ban.onclick = () => playerAction(server, p.userid, 'ban');
+                row.appendChild(ban);
+                container.appendChild(row);
+            });
+        }
+
+        async function playerAction(server, userid, action) {
+            const res = await fetch(`/player_action/${server}/${action}/${userid}`, {method: 'POST'});
+            const data = await res.json();
+            console.log(data);
+            fetchPlayers();
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add `parse_players` helper and player management routes
- display connected players in the UI and add kick/ban buttons

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e2ce34988332b4490262161f75e5