### PR TITLE
Add pytest suite for decoding and route checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Flask RCON Admin
+
+This project provides a simple Flask application for sending RCON commands to a game server.
+
+## Running tests
+
+Ensure `flask` and `pytest` are installed and then run:
+
+```bash
+pip install flask pytest
+pytest
+```

--- a/tests/test_decode_resp.py
+++ b/tests/test_decode_resp.py
@@ -1,0 +1,12 @@
+import pytest
+from app import decode_resp
+
+
+def test_decode_single_chunk():
+    data = b"\xff\xff\xff\xffHello world\x00"
+    assert decode_resp(data) == "Hello world"
+
+
+def test_decode_multiple_chunks():
+    data = b"\xff\xff\xff\xffLine1\n\xff\xff\xff\xffLine2\r\n"
+    assert decode_resp(data) == "Line1\nLine2"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,16 @@
+from app import app, save_servers
+
+
+def test_get_server_returns_data(tmp_path):
+    server_file = tmp_path / "servers.json"
+    # patch server file location
+    app.SERVER_FILE = str(server_file)
+
+    servers = {"myserver": {"host": "127.0.0.1", "port": "27015", "password": "pw"}}
+    save_servers(servers)
+
+    with app.test_client() as client:
+        resp = client.get("/get_server/myserver")
+        assert resp.status_code == 200
+        assert resp.get_json() == servers["myserver"]
+


### PR DESCRIPTION
## Summary
- create README with simple test instructions
- add tests for decode_resp output parsing
- add Flask route test for /get_server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6866e2d76284833299bd0bb15e36aed8