### PR TITLE
Clarify server saving comment

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ def load_servers():
             return json.load(f)
     return {}
 
-# Save new servers to JSON
+# Save the full server profile dictionary to JSON
 def save_servers(servers):
     with open(SERVER_FILE, 'w', encoding='utf-8') as f:
         json.dump(servers, f, indent=2)


### PR DESCRIPTION
## Summary
- clarify that `save_servers` persists the full profile dictionary

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6866e2db7cbc83329b14f06e72380816