### PR TITLE
Enhance RCON admin panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,6 +105,7 @@ def parse_players(status_output: str):
 def index():
     servers = load_servers()
     output = ""
+    selected_server = ""
 
     if request.method == 'POST':
         form = request.form.to_dict()
@@ -114,6 +115,7 @@ def index():
         port = form.get('port', '27015').strip()
         password = form.get('password', '').strip()
         mapfile = form.get('mapfile', 'mapcycle.txt').strip()
+        selected_server = form.get('server', '').strip()
 
         # Handle "say" message if submitted
         say_message = form.get("say_message")
@@ -137,8 +139,12 @@ def index():
         if new_name and host:
             servers[new_name] = {'host': host, 'port': port, 'password': password, 'mapfile': mapfile}
             save_servers(servers)
+            selected_server = new_name
 
-    return render_template('index.html', servers=servers, output=output)
+    else:
+        selected_server = request.args.get('server', '')
+
+    return render_template('index.html', servers=servers, output=output, selected_server=selected_server)
 
 # API to fetch server config
 @app.route('/get_server/<name>')

--- a/app.py
+++ b/app.py
@@ -143,7 +143,10 @@ def index():
 # API to fetch server config
 @app.route('/get_server/<name>')
 def get_server(name):
-    return jsonify(load_servers().get(name, {}))
+    data = load_servers().get(name, {})
+    if data and 'mapfile' not in data:
+        data['mapfile'] = 'mapcycle.txt'
+    return jsonify(data)
 
 # API to fetch console log
 @app.route('/console')

--- a/app.py
+++ b/app.py
@@ -126,6 +126,19 @@ def index():
             selected_server = ""
             return render_template('index.html', servers=servers, output=output, selected_server=selected_server)
 
+        # Edit existing profile details
+        if 'edit_profile' in form:
+            if selected_server and selected_server in servers:
+                servers[selected_server] = {
+                    'host': host,
+                    'port': port,
+                    'password': password,
+                    'mapfile': mapfile
+                }
+                save_servers(servers)
+                output = f"Updated profile {selected_server}"
+            return render_template('index.html', servers=servers, output=output, selected_server=selected_server)
+
         # Handle "say" message if submitted
         say_message = form.get("say_message")
         if say_message:

--- a/app.py
+++ b/app.py
@@ -117,6 +117,15 @@ def index():
         mapfile = form.get('mapfile', 'mapcycle.txt').strip()
         selected_server = form.get('server', '').strip()
 
+        # Delete an existing profile if requested
+        if 'delete_profile' in form:
+            if selected_server and selected_server in servers:
+                del servers[selected_server]
+                save_servers(servers)
+                output = f"Deleted profile {selected_server}"
+            selected_server = ""
+            return render_template('index.html', servers=servers, output=output, selected_server=selected_server)
+
         # Handle "say" message if submitted
         say_message = form.get("say_message")
         if say_message:

--- a/app.py
+++ b/app.py
@@ -113,6 +113,7 @@ def index():
         host = form.get('host', '').strip()
         port = form.get('port', '27015').strip()
         password = form.get('password', '').strip()
+        mapfile = form.get('mapfile', 'mapcycle.txt').strip()
 
         # Handle "say" message if submitted
         say_message = form.get("say_message")
@@ -134,7 +135,7 @@ def index():
         # Save server profile if name + host are provided
         new_name = form.get('new_name', '').strip()
         if new_name and host:
-            servers[new_name] = {'host': host, 'port': port, 'password': password}
+            servers[new_name] = {'host': host, 'port': port, 'password': password, 'mapfile': mapfile}
             save_servers(servers)
 
     return render_template('index.html', servers=servers, output=output)
@@ -160,6 +161,18 @@ def get_players():
     output = decode_resp(raw)
     append_log(output)
     return jsonify(parse_players(output))
+
+# API to load maps from a mapcycle file
+@app.route('/maps', methods=['POST'])
+def get_maps():
+    data = request.get_json(force=True)
+    path = data.get('file', 'mapcycle.txt')
+    try:
+        with open(path, encoding='utf-8') as f:
+            maps = [line.strip() for line in f if line.strip() and not line.startswith(';')]
+        return jsonify(maps)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
 
 # API to send arbitrary command via AJAX
 @app.route('/command', methods=['POST'])

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,6 +42,7 @@
                 </div>
                 <div class="pt-6 flex space-x-2">
                     <button type="submit" name="save_profile" value="1" class="bg-yellow-600 hover:bg-yellow-700 px-4 py-2 rounded">Save Profile</button>
+                    <button type="submit" name="edit_profile" value="1" class="bg-green-600 hover:bg-green-700 px-4 py-2 rounded">Edit Profile</button>
                     <button type="submit" name="delete_profile" value="1" class="bg-red-600 hover:bg-red-700 px-4 py-2 rounded">Delete Profile</button>
                 </div>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,13 +10,14 @@
         <h1 class="text-3xl font-bold mb-6 text-yellow-400">CS 1.6 RCON Admin Panel</h1>
 
         <form method="POST" class="space-y-4 bg-gray-800 p-6 rounded-lg shadow-lg">
+            {% set cfg = servers.get(selected_server, {}) %}
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
                     <label class="block mb-1">Server</label>
                     <select name="server" id="server" onchange="loadServer()" class="w-full p-2 rounded text-black">
                         <option value="">-- Select --</option>
                         {% for name in servers %}
-                            <option value="{{ name }}" {% if name == request.form.server %}selected{% endif %}>{{ name }}</option>
+                            <option value="{{ name }}" {% if name == selected_server %}selected{% endif %}>{{ name }}</option>
                         {% endfor %}
                     </select>
                 </div>
@@ -26,18 +27,18 @@
                 </div>
                 <div>
                     <label class="block mb-1">RCON Password</label>
-                    <input type="password" name="password" id="password" value="{{ request.form.password }}" class="w-full p-2 rounded text-black">
+                    <input type="password" name="password" id="password" value="{{ cfg.get('password', request.form.password) }}" class="w-full p-2 rounded text-black">
                 </div>
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
                     <label class="block mb-1">Host</label>
-                    <input type="text" name="host" id="host" value="{{ request.form.host }}" class="w-full p-2 rounded text-black">
+                    <input type="text" name="host" id="host" value="{{ cfg.get('host', request.form.host) }}" class="w-full p-2 rounded text-black">
                 </div>
                 <div>
                     <label class="block mb-1">Port</label>
-                    <input type="text" name="port" id="port" value="{{ request.form.port or '27015' }}" class="w-full p-2 rounded text-black">
+                    <input type="text" name="port" id="port" value="{{ cfg.get('port', request.form.port or '27015') }}" class="w-full p-2 rounded text-black">
                 </div>
                 <div class="pt-6">
                     <button type="submit" name="save_profile" value="1" class="bg-yellow-600 hover:bg-yellow-700 px-4 py-2 rounded">Save Profile</button>
@@ -47,7 +48,7 @@
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
                     <label class="block mb-1">Mapcycle File</label>
-                    <input type="text" id="mapfile" name="mapfile" value="{{ request.form.mapfile or 'mapcycle.txt' }}" class="w-full p-2 rounded text-black">
+                    <input type="text" id="mapfile" name="mapfile" value="{{ cfg.get('mapfile', request.form.mapfile or 'mapcycle.txt') }}" class="w-full p-2 rounded text-black">
                 </div>
                 <div class="pt-6">
                     <button type="button" onclick="loadMaps()" class="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded">Load Maps</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -108,9 +108,31 @@
             list.innerHTML = '';
             players.forEach(p => {
                 const li = document.createElement('li');
-                li.textContent = `${p.name} (id ${p.userid}, ping ${p.ping})`;
+                li.innerHTML = `${p.name} (id ${p.userid}, ping ${p.ping}) ` +
+                    `<button class="bg-red-600 px-2 rounded mr-2" onclick="kickPlayer('${p.userid}')">Kick</button>` +
+                    `<button class="bg-yellow-600 px-2 rounded" onclick="banPlayer('${p.userid}','${p.ip}')">Ban</button>`;
                 list.appendChild(li);
             });
+        }
+
+        async function sendCommand(command) {
+            const host = document.getElementById('host').value;
+            const port = document.getElementById('port').value;
+            const password = document.getElementById('password').value;
+            await fetch('/command', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ host, port, password, command })
+            });
+            refreshConsole();
+        }
+
+        function kickPlayer(id) {
+            sendCommand(`kick #${id}`);
+        }
+
+        function banPlayer(id, ip) {
+            sendCommand(`addip 0 ${ip};writeip;kick #${id}`);
         }
 
         async function refreshConsole() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,8 +40,9 @@
                     <label class="block mb-1">Port</label>
                     <input type="text" name="port" id="port" value="{{ cfg.get('port', request.form.port or '27015') }}" class="w-full p-2 rounded text-black">
                 </div>
-                <div class="pt-6">
+                <div class="pt-6 flex space-x-2">
                     <button type="submit" name="save_profile" value="1" class="bg-yellow-600 hover:bg-yellow-700 px-4 py-2 rounded">Save Profile</button>
+                    <button type="submit" name="delete_profile" value="1" class="bg-red-600 hover:bg-red-700 px-4 py-2 rounded">Delete Profile</button>
                 </div>
             </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,23 @@
                 </div>
             </div>
 
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                    <label class="block mb-1">Mapcycle File</label>
+                    <input type="text" id="mapfile" name="mapfile" value="{{ request.form.mapfile or 'mapcycle.txt' }}" class="w-full p-2 rounded text-black">
+                </div>
+                <div class="pt-6">
+                    <button type="button" onclick="loadMaps()" class="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded">Load Maps</button>
+                </div>
+                <div>
+                    <select id="mapSelect" class="w-full p-2 rounded text-black"></select>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-2">
+                <button type="button" onclick="changeMap()" class="bg-green-600 hover:bg-green-700 px-4 py-2 rounded">Change Map</button>
+            </div>
+
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4">
                 <button name="command" value="status" class="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded">Status</button>
                 <button type="button" onclick="startAuto()" class="bg-indigo-500 hover:bg-indigo-600 px-4 py-2 rounded">Auto Refresh</button>
@@ -92,6 +109,7 @@
             document.getElementById('host').value = data.host || '';
             document.getElementById('port').value = data.port || '27015';
             document.getElementById('password').value = data.password || '';
+            document.getElementById('mapfile').value = data.mapfile || 'mapcycle.txt';
         }
 
         async function fetchPlayers() {
@@ -133,6 +151,35 @@
 
         function banPlayer(id, ip) {
             sendCommand(`addip 0 ${ip};writeip;kick #${id}`);
+        }
+
+        async function loadMaps() {
+            const file = document.getElementById('mapfile').value;
+            const res = await fetch('/maps', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ file })
+            });
+            const maps = await res.json();
+            const select = document.getElementById('mapSelect');
+            select.innerHTML = '';
+            if (Array.isArray(maps)) {
+                maps.forEach(m => {
+                    const opt = document.createElement('option');
+                    opt.value = m;
+                    opt.textContent = m;
+                    select.appendChild(opt);
+                });
+            } else if (maps.error) {
+                alert('Error: ' + maps.error);
+            }
+        }
+
+        function changeMap() {
+            const map = document.getElementById('mapSelect').value;
+            if (map) {
+                sendCommand(`changelevel ${map}`);
+            }
         }
 
         async function refreshConsole() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -104,7 +104,7 @@
             const name = document.getElementById('server').value;
             if (!name) return;
 
-            const res = await fetch('/get_server/' + name);
+            const res = await fetch('/get_server/' + encodeURIComponent(name));
             const data = await res.json();
             document.getElementById('host').value = data.host || '';
             document.getElementById('port').value = data.port || '27015';

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4">
                 <button name="command" value="status" class="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded">Status</button>
-                <button type="button" onclick="autoRefresh()" class="bg-indigo-500 hover:bg-indigo-600 px-4 py-2 rounded">Auto Refresh</button>
+                <button type="button" onclick="startAuto()" class="bg-indigo-500 hover:bg-indigo-600 px-4 py-2 rounded">Auto Refresh</button>
                 <button name="command" value="map de_dust2" class="bg-green-500 hover:bg-green-600 px-4 py-2 rounded">Map: Dust2</button>
                 <button name="command" value="sv_restart 1" class="bg-purple-500 hover:bg-purple-600 px-4 py-2 rounded">Restart</button>
             </div>
@@ -68,6 +68,18 @@
                 </div>
             {% endif %}
         </form>
+
+        <div class="mt-8">
+            <h2 class="text-xl mb-2">Players</h2>
+            <ul id="playersList" class="list-disc pl-5"></ul>
+            <button type="button" onclick="fetchPlayers()" class="mt-2 bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded">Refresh Players</button>
+        </div>
+
+        <div class="mt-8">
+            <h2 class="text-xl mb-2">Console Log</h2>
+            <pre id="consoleLog" class="bg-black p-4 rounded text-green-400 font-mono whitespace-pre-wrap h-64 overflow-y-auto"></pre>
+            <button type="button" onclick="refreshConsole()" class="mt-2 bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded">Refresh Console</button>
+        </div>
     </div>
 
     <script>
@@ -82,22 +94,37 @@
             document.getElementById('password').value = data.password || '';
         }
 
-        function autoRefresh() {
+        async function fetchPlayers() {
+            const host = document.getElementById('host').value;
+            const port = document.getElementById('port').value;
+            const password = document.getElementById('password').value;
+            const res = await fetch('/players', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ host, port, password })
+            });
+            const players = await res.json();
+            const list = document.getElementById('playersList');
+            list.innerHTML = '';
+            players.forEach(p => {
+                const li = document.createElement('li');
+                li.textContent = `${p.name} (id ${p.userid}, ping ${p.ping})`;
+                list.appendChild(li);
+            });
+        }
+
+        async function refreshConsole() {
+            const res = await fetch('/console');
+            const logs = await res.json();
+            document.getElementById('consoleLog').textContent = logs.join('\n');
+        }
+
+        function startAuto() {
+            fetchPlayers();
+            refreshConsole();
             setInterval(() => {
-                const form = document.querySelector('form');
-
-                // Remove any previous auto-added input
-                const existing = document.querySelector('input[name="command"][data-auto="true"]');
-                if (existing) existing.remove();
-
-                const input = document.createElement('input');
-                input.type = 'hidden';
-                input.name = 'command';
-                input.value = 'status';
-                input.setAttribute('data-auto', 'true'); // so we can identify it
-                form.appendChild(input);
-
-                form.submit();
+                fetchPlayers();
+                refreshConsole();
             }, 10000); // every 10 seconds
         }
     </script>


### PR DESCRIPTION
## Summary
- keep a small in-memory console log
- parse `status` output to list players
- add `/console` and `/players` endpoints
- store command output in the console log
- show player list and console log in the UI
- support auto-refresh via JavaScript

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6866e4d2ad748332bcd96e37807a57ee