### PR TITLE
Add War3FT and AMXX management features

### DIFF
--- a/templates/amxx_plugins.html
+++ b/templates/amxx_plugins.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>AMXX Plugins</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-white p-6">
+    <h1 class="text-2xl mb-4">AMXX Plugins</h1>
+    <div class="mb-4 space-x-2">
+        <input id="host" placeholder="Host" class="text-black p-1 rounded" />
+        <input id="port" value="27015" placeholder="Port" class="text-black p-1 rounded" />
+        <input id="password" type="password" placeholder="RCON Password" class="text-black p-1 rounded" />
+        <button onclick="loadList()" class="bg-blue-600 px-3 py-1 rounded">Load</button>
+    </div>
+    <table class="min-w-full text-left" id="tbl"></table>
+
+    <div id="toast" class="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded hidden"></div>
+    <script>
+        const csrfToken="{{ csrf_token() }}";
+        async function loadList(){
+            const host=document.getElementById('host').value;
+            const port=document.getElementById('port').value;
+            const password=document.getElementById('password').value;
+            const res=await fetch(`/amxx/plugins?json=1&host=${host}&port=${port}&password=${password}`);
+            const data=await res.json();
+            const tbl=document.getElementById('tbl');
+            tbl.innerHTML='<tr><th>ID</th><th>Name</th><th>State</th><th></th></tr>';
+            data.forEach(p=>{
+                const tr=document.createElement('tr');
+                const btnTxt=p.enabled?'Disable':'Enable';
+                tr.innerHTML=`<td>${p.id}</td><td>${p.name}</td><td>${p.enabled?'on':'off'}</td>`+
+                    `<td><button class='bg-gray-700 px-2 rounded' onclick="toggle(${p.id},${p.enabled})">${btnTxt}</button></td>`;
+                tbl.appendChild(tr);
+            });
+        }
+        async function toggle(id,on){
+            const host=document.getElementById('host').value;
+            const port=document.getElementById('port').value;
+            const password=document.getElementById('password').value;
+            const action=on?'disable':'enable';
+            const res=await fetch(`/amxx/plugins/${id}/${action}`,{
+                method:'POST',
+                headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
+                body:JSON.stringify({host,port,password})
+            });
+            const out=await res.json();
+            showToast('Done');
+            loadList();
+        }
+        function showToast(msg,err=false){
+            const t=document.getElementById('toast');
+            t.textContent=msg;
+            t.classList.remove('hidden');
+            t.classList.toggle('bg-red-600',err);
+            t.classList.toggle('bg-green-600',!err);
+            setTimeout(()=>t.classList.add('hidden'),3000);
+        }
+    </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
         <h1 class="text-3xl font-bold mb-6 text-yellow-400">CS 1.6 RCON Admin Panel</h1>
 
         <form method="POST" class="space-y-4 bg-gray-800 p-6 rounded-lg shadow-lg">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             {% set cfg = servers.get(selected_server, {}) %}
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
@@ -103,6 +104,15 @@
     </div>
 
     <script>
+        const csrfToken = "{{ csrf_token() }}";
+        function showToast(msg, err=false) {
+            const t = document.getElementById('toast');
+            t.textContent = msg;
+            t.classList.remove('hidden');
+            t.classList.toggle('bg-red-600', err);
+            t.classList.toggle('bg-green-600', !err);
+            setTimeout(() => t.classList.add('hidden'), 3000);
+        }
           async function loadServer() {
               const name = document.getElementById('server').value;
               if (!name) return;
@@ -122,7 +132,7 @@
               const password = document.getElementById('password').value;
               const res = await fetch('/players', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
                 body: JSON.stringify({ host, port, password })
             });
             const players = await res.json();
@@ -144,7 +154,7 @@
               if (!host) return;
               const res = await fetch('/server_status', {
                   method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
+                  headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
                   body: JSON.stringify({ host, port, password })
               });
               const data = await res.json();
@@ -157,10 +167,11 @@
             const password = document.getElementById('password').value;
             await fetch('/command', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
                 body: JSON.stringify({ host, port, password, command })
             });
             refreshConsole();
+            showToast('Command sent');
         }
 
         function kickPlayer(id) {
@@ -175,7 +186,7 @@
             const file = document.getElementById('mapfile').value;
             const res = await fetch('/maps', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
                 body: JSON.stringify({ file })
             });
             const maps = await res.json();
@@ -189,7 +200,7 @@
                     select.appendChild(opt);
                 });
             } else if (maps.error) {
-                alert('Error: ' + maps.error);
+                showToast('Error: ' + maps.error, true);
             }
         }
 
@@ -219,5 +230,6 @@
 
         document.addEventListener('DOMContentLoaded', checkStatus);
     </script>
+    <div id="toast" class="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded hidden"></div>
 </body>
 </html>

--- a/templates/plugin_config.html
+++ b/templates/plugin_config.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ plugin }} Config</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-white p-6">
+    <h1 class="text-2xl mb-4">{{ plugin }} Config</h1>
+    <form id="cfgForm" class="space-y-2"></form>
+    <button onclick="saveCfg()" class="mt-4 bg-green-600 px-4 py-2 rounded">Save</button>
+    <div id="toast" class="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded hidden"></div>
+    <script>
+        const csrfToken="{{ csrf_token() }}";
+        async function loadCfg(){
+            const res=await fetch(`/amxx/configs/{{ plugin }}?json=1`);
+            const data=await res.json();
+            const form=document.getElementById('cfgForm');
+            form.innerHTML='';
+            for(const k in data.other||data){
+                const div=document.createElement('div');
+                const val=data.other?data.other[k]:data[k];
+                div.innerHTML=`<label class='mr-2'>${k}</label><input data-key='${k}' value='${val}' class='text-black p-1 rounded'/>`;
+                form.appendChild(div);
+            }
+        }
+        async function saveCfg(){
+            const updates={};
+            document.querySelectorAll('#cfgForm input[data-key]').forEach(i=>updates[i.dataset.key]=i.value);
+            const res=await fetch(`/amxx/configs/{{ plugin }}`,{
+                method:'POST',
+                headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
+                body:JSON.stringify(updates)
+            });
+            const out=await res.json();
+            if(out.success) showToast('Saved');
+            else showToast(out.error,true);
+        }
+        function showToast(msg,err=false){
+            const t=document.getElementById('toast');
+            t.textContent=msg;
+            t.classList.remove('hidden');
+            t.classList.toggle('bg-red-600',err);
+            t.classList.toggle('bg-green-600',!err);
+            setTimeout(()=>t.classList.add('hidden'),3000);
+        }
+        document.addEventListener('DOMContentLoaded',loadCfg);
+    </script>
+</body>
+</html>

--- a/templates/war3ft_config.html
+++ b/templates/war3ft_config.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>War3FT Config</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-white p-6">
+    <h1 class="text-2xl mb-4">War3FT Config</h1>
+    <div class="mb-4 space-x-2">
+        <input id="host" placeholder="Host" class="text-black p-1 rounded" />
+        <input id="port" value="27015" placeholder="Port" class="text-black p-1 rounded" />
+        <input id="password" type="password" placeholder="RCON Password" class="text-black p-1 rounded" />
+        <button onclick="reloadPlugin()" class="bg-purple-600 px-3 py-1 rounded">Reload Plugin</button>
+    </div>
+    <form id="cfgForm" class="space-y-4"></form>
+    <button onclick="saveCfg()" class="mt-4 bg-green-600 px-4 py-2 rounded">Save</button>
+
+    <div id="toast" class="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded hidden"></div>
+
+    <script>
+        const csrfToken = "{{ csrf_token() }}";
+        const sections = ['Saving Options','Gameplay','Skills','Items','Disables'];
+        async function loadCfg(){
+            const res = await fetch('/war3ft/config?json=1');
+            const data = await res.json();
+            const form = document.getElementById('cfgForm');
+            form.innerHTML='';
+            sections.forEach(sec=>{
+                const group=document.createElement('div');
+                group.innerHTML=`<h2 class='text-xl mb-2'>${sec}</h2>`;
+                const opts=data[sec]||{};
+                for(const k in opts){
+                    const div=document.createElement('div');
+                    div.className='mb-2';
+                    div.innerHTML=`<label class='mr-2'>${k}</label><input data-key='${k}' value='${opts[k]}' class='text-black p-1 rounded'/>`;
+                    group.appendChild(div);
+                }
+                form.appendChild(group);
+            });
+        }
+        async function saveCfg(){
+            const updates={};
+            document.querySelectorAll('#cfgForm input[data-key]').forEach(i=>{updates[i.dataset.key]=i.value});
+            const res=await fetch('/war3ft/config',{
+                method:'POST',
+                headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
+                body:JSON.stringify(updates)
+            });
+            const out=await res.json();
+            if(out.success) showToast('Saved');
+            else showToast(out.error,true);
+        }
+        async function reloadPlugin(){
+            const host=document.getElementById('host').value;
+            const port=document.getElementById('port').value;
+            const password=document.getElementById('password').value;
+            const res=await fetch('/war3ft/reload',{
+                method:'POST',
+                headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
+                body:JSON.stringify({host,port,password})
+            });
+            const out=await res.json();
+            if(out.output) showToast('Reloaded');
+        }
+        function showToast(msg,err=false){
+            const t=document.getElementById('toast');
+            t.textContent=msg;
+            t.classList.remove('hidden');
+            t.classList.toggle('bg-red-600',err);
+            t.classList.toggle('bg-green-600',!err);
+            setTimeout(()=>t.classList.add('hidden'),3000);
+        }
+        document.addEventListener('DOMContentLoaded',loadCfg);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add CSRF utilities and helpers
- implement routes for War3FT config editing and plugin reload
- implement AMXX plugin manager and generic config editor
- add templates for War3FT, AMXX plugin management, and plugin config
- include CSRF tokens in index and AJAX requests with toast feedback

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686849388b0c833295639c8e3c3ba4e0