### PR TITLE
Expose mod management links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,11 @@
 </head>
 <body class="bg-gray-900 text-white">
     <div class="max-w-4xl mx-auto p-6">
-        <h1 class="text-3xl font-bold mb-6 text-yellow-400">CS 1.6 RCON Admin Panel</h1>
+        <h1 class="text-3xl font-bold mb-4 text-yellow-400">CS 1.6 RCON Admin Panel</h1>
+        <div class="mb-6 space-x-2">
+            <a href="/war3ft/config" class="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded">War3FT Config</a>
+            <a href="/amxx/plugins" class="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded">AMXX Plugins</a>
+        </div>
 
         <form method="POST" class="space-y-4 bg-gray-800 p-6 rounded-lg shadow-lg">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/templates/plugin_config.html
+++ b/templates/plugin_config.html
@@ -17,20 +17,12 @@
             const data=await res.json();
             const form=document.getElementById('cfgForm');
             form.innerHTML='';
- j2bzqd-codex/add-war3ft-config-editor-and-plugin-manager
-            Object.entries(data).forEach(([k,v])=>{
-                const div=document.createElement('div');
-                div.innerHTML=`<label class='mr-2'>${k}</label><input data-key='${k}' value='${v}' class='text-black p-1 rounded'/>`;
-                form.appendChild(div);
-            });
-=======
             for(const k in data.other||data){
                 const div=document.createElement('div');
                 const val=data.other?data.other[k]:data[k];
                 div.innerHTML=`<label class='mr-2'>${k}</label><input data-key='${k}' value='${val}' class='text-black p-1 rounded'/>`;
                 form.appendChild(div);
             }
- Chatgptcodex2
         }
         async function saveCfg(){
             const updates={};


### PR DESCRIPTION
## Summary
- add navigation links to War3FT and AMXX management pages
- clean leftover merge markers from `plugin_config.html`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686855cfe7a48332aaec6049e4c98bcd