### PR TITLE
Add profile selection for secondary pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ Alle Server-Profile werden in der Datei `servers.json` im gleichen Verzeichnis a
 - War3FT-Konfiguration unter `/war3ft/config` bearbeiten
 - Plugin-Hotreload über `/war3ft/reload`
 - AMXX-Plugins und Konfigs unter `/amxx/...` verwalten
+
+## Neue Features
+- Serverprofile-Auswahl und Zurück-Link auf `/war3ft/config` und `/amxx/plugins`

--- a/app.py
+++ b/app.py
@@ -321,7 +321,8 @@ def war3ft_config():
 
     if request.accept_mimetypes.best == 'application/json' or request.args.get('json'):
         return jsonify(parse_config(WAR3FT_CFG, WAR3FT_SECTIONS))
-    return render_template('war3ft_config.html')
+    servers = load_servers()
+    return render_template('war3ft_config.html', servers=servers)
 
 @app.route('/war3ft/reload', methods=['POST'])
 def war3ft_reload():
@@ -353,7 +354,8 @@ def amxx_plugins():
                 enabled = 'running' in line or 'loaded' in line
                 plugins.append({'id': pid, 'name': name, 'enabled': enabled})
         return jsonify(plugins)
-    return render_template('amxx_plugins.html')
+    servers = load_servers()
+    return render_template('amxx_plugins.html', servers=servers)
 
 @app.route('/amxx/plugins/<int:pid>/<action>', methods=['POST'])
 def toggle_plugin(pid, action):

--- a/templates/amxx_plugins.html
+++ b/templates/amxx_plugins.html
@@ -6,6 +6,15 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white p-6">
+    <div class="mb-4 space-x-2">
+        <a href="/" class="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded">&larr; Back</a>
+        <select id="server" onchange="loadServer()" class="text-black p-1 rounded">
+            <option value="">-- Server --</option>
+            {% for name in servers %}
+                <option value="{{ name }}">{{ name }}</option>
+            {% endfor %}
+        </select>
+    </div>
     <h1 class="text-2xl mb-4">AMXX Plugins</h1>
     <div class="mb-4 space-x-2">
         <input id="host" placeholder="Host" class="text-black p-1 rounded" />
@@ -47,6 +56,15 @@
             const out=await res.json();
             showToast('Done');
             loadList();
+        }
+        async function loadServer(){
+            const name=document.getElementById('server').value;
+            if(!name) return;
+            const res=await fetch('/get_server/'+encodeURIComponent(name));
+            const data=await res.json();
+            document.getElementById('host').value=data.host||'';
+            document.getElementById('port').value=data.port||'27015';
+            document.getElementById('password').value=data.password||'';
         }
         function showToast(msg,err=false){
             const t=document.getElementById('toast');

--- a/templates/war3ft_config.html
+++ b/templates/war3ft_config.html
@@ -6,6 +6,15 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white p-6">
+    <div class="mb-4 space-x-2">
+        <a href="/" class="bg-gray-700 hover:bg-gray-600 px-3 py-1 rounded">&larr; Back</a>
+        <select id="server" onchange="loadServer()" class="text-black p-1 rounded">
+            <option value="">-- Server --</option>
+            {% for name in servers %}
+                <option value="{{ name }}">{{ name }}</option>
+            {% endfor %}
+        </select>
+    </div>
     <h1 class="text-2xl mb-4">War3FT Config</h1>
     <div class="mb-4 space-x-2">
         <input id="host" placeholder="Host" class="text-black p-1 rounded" />
@@ -62,6 +71,15 @@
             });
             const out=await res.json();
             if(out.output) showToast('Reloaded');
+        }
+        async function loadServer(){
+            const name=document.getElementById('server').value;
+            if(!name) return;
+            const res=await fetch('/get_server/'+encodeURIComponent(name));
+            const data=await res.json();
+            document.getElementById('host').value=data.host||'';
+            document.getElementById('port').value=data.port||'27015';
+            document.getElementById('password').value=data.password||'';
         }
         function showToast(msg,err=false){
             const t=document.getElementById('toast');


### PR DESCRIPTION
## Summary
- enable server profile dropdown and Back links on `/war3ft/config` and `/amxx/plugins`
- expose server lists in backend for these pages
- document feature in README

## Testing
- `pip install -r requirements.txt` *(fails: requirements file missing)*
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6868606cfcec8332b4dc3a318853fe3a